### PR TITLE
Include editor reference in init event

### DIFF
--- a/editor/src/main.vue
+++ b/editor/src/main.vue
@@ -69,7 +69,7 @@ export default {
       this.editor = ace.edit(this.$refs.editor);
       this.editor.$blockScrolling = Infinity;
       this.session = this.editor.getSession();
-      this.$emit("init");
+      this.$emit("init", this.editor);
       this.setMode();
       this.setTheme();
       this.setFontSize();

--- a/editor/src/split.vue
+++ b/editor/src/split.vue
@@ -77,7 +77,7 @@ export default {
   methods: {
     init() {
       this.editor = ace.edit(this.$refs.editor);
-      this.$emit("init");
+      this.$emit("init", this.editor);
       this.split = new Split(
         this.editor.container,
         `ace/theme/${this.theme}`,


### PR DESCRIPTION
This makes the behavior match the documentation, and allows more
thorough configuration of editor instance.